### PR TITLE
Added COT field enumeration

### DIFF
--- a/LXMF/LXMF.py
+++ b/LXMF/LXMF.py
@@ -15,7 +15,7 @@ FIELD_THREAD           = 0x08
 FIELD_COMMANDS         = 0x09
 FIELD_RESULTS          = 0x0A
 FIELD_GROUP            = 0x0B
-FIELD_COT              = 0x0C # Cursor on Target for TAK integration
+FIELD_COT              = 0x20 # Cursor on Target for TAK integration
 
 # Audio modes for the data structure in FIELD_AUDIO
 

--- a/LXMF/LXMF.py
+++ b/LXMF/LXMF.py
@@ -15,6 +15,7 @@ FIELD_THREAD           = 0x08
 FIELD_COMMANDS         = 0x09
 FIELD_RESULTS          = 0x0A
 FIELD_GROUP            = 0x0B
+FIELD_COT              = 0x0C # Cursor on Target for TAK integration
 
 # Audio modes for the data structure in FIELD_AUDIO
 


### PR DESCRIPTION
Enumerated the Cursor on Target protocol used in Team Awareness Kit systems into base LXMF definitions. Designated 0x20 in order to avoid any collisions in 0x00-0x1f space and to designate it as an additional field, not core to LXMF features.