### PR TITLE
`LXMessage.unpack`: check if `title` and `content` are byte arrays or strings

### DIFF
--- a/LXMF/LXMessage.py
+++ b/LXMF/LXMessage.py
@@ -757,8 +757,16 @@ class LXMessage:
         message.timestamp   = timestamp
         message.packed      = lxmf_bytes
         message.packed_size = len(lxmf_bytes)
-        message.set_title_from_bytes(title_bytes)
-        message.set_content_from_bytes(content_bytes)
+
+        if type(title_bytes) is bytes:
+            message.set_title_from_bytes(title_bytes)
+        elif type(title_bytes) is str:
+            message.set_title_from_string(title_bytes)
+
+        if type(content_bytes) is bytes:
+            message.set_content_from_bytes(content_bytes)
+        elif type(content_bytes) is str:
+            message.set_content_from_string(content_bytes)
 
         try:
             if source:


### PR DESCRIPTION
If a the `msgpack`ed portion of an LXMessage uses strings (`fixstr` tags `0xa0` to `0xbf`, and probably `str_8` (`0xd9`), `str_16` (`0xda`), and `str_32` (`0xdb`) as well) instead of byte arrays, LXMF will happily unpack them but then crash when trying to decode the string. For example:

```hexdump
0090: 94 CB 41 D9 EF DB 0D 00  00 00 AC 48 65 6C 6C 6F  ..A........Hello
00a0: 2C 20 6C 78 6D 66 21 A0  C0                       , lxmf!..       
```

(Side note, is there a reason to LXMF uses byte arrays in the msgpack instead of strings? Like, does msgpack not specify UTF-8 as the string format or something?)

This PR changes `unpack` to have logic similar to `LXMessage.__init__`, where it will always decode it into UTF-8 byte array based on the type. 