### PR TITLE
Add support for msgpack strings as LXMF dest names

### DIFF
--- a/LXMF/LXMF.py
+++ b/LXMF/LXMF.py
@@ -115,6 +115,9 @@ def display_name_from_app_data(app_data=None):
                     if dn == None:
                         return None
                     else:
+                        # if it was packed as a string, then we don't need to decode it
+                        if isinstance(dn, str):
+                            return dn
                         try:
                             decoded = dn.decode("utf-8")
                             return decoded


### PR DESCRIPTION
Added check for msgpack utf-8 strings in case an LXMF client sent that for their name. This is important since not all msgpack libraries support binary strings. (like ArduinoJson 6.x.x that microReticulum uses) and the names are immediately decoded into a utf-8 string anyway after being unpacked. 