### PR TITLE
Fix stored messages always getting deleted if config path has underscores

### DIFF
--- a/LXMF/LXMRouter.py
+++ b/LXMF/LXMRouter.py
@@ -1090,9 +1090,10 @@ class LXMRouter:
         for transient_id in self.propagation_entries.copy():
             entry = self.propagation_entries[transient_id]
             filepath = entry[1]
-            components = filepath.split("_")
+            filename = os.path.split(filepath)[-1]
+            components = filename.split("_")
 
-            if len(components) == 2 and float(components[1]) > 0 and len(os.path.split(components[0])[1]) == (RNS.Identity.HASHLENGTH//8)*2:
+            if len(components) == 2 and float(components[1]) > 0 and len(components[0]) == (RNS.Identity.HASHLENGTH//8)*2:
                 timestamp = float(components[1])
                 if now > timestamp+LXMRouter.MESSAGE_EXPIRY:
                     RNS.log("Purging message "+RNS.prettyhexrep(transient_id)+" due to expiry", RNS.LOG_EXTREME)


### PR DESCRIPTION
Currently `LXMRouter.clean_message_store` treats the `filepath` of a propagation entry as if it's actually a filename, it splits it by `_` to check the filename components - the hash and the timestamp. But if the `filepath` has other underscores then that causes the `len(components) == 2` check to fail, so all stored messages get deleted "due to invalid file path". This makes using the `--config` parameter of LXMF quite dangerous, which is how I encountered this bug.